### PR TITLE
[New Game Menu] Make remove party member a state

### DIFF
--- a/Scenes/New Game Scene.tscn
+++ b/Scenes/New Game Scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://d20j14agk0xhd"]
+[gd_scene load_steps=16 format=3 uid="uid://d20j14agk0xhd"]
 
 [ext_resource type="Script" path="res://Scripts/UI/New Game Menu/NewGameController.gd" id="1_al584"]
 [ext_resource type="PackedScene" uid="uid://5a4bwrowsmnr" path="res://Scenes/UI/Portrait Displayer Panel.tscn" id="2_o2gpb"]
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://bo0nvc14cnaxw" path="res://Scenes/UI/Party Member Slot.tscn" id="4_k01rt"]
 [ext_resource type="Script" path="res://Scripts/UI/New Game Menu/States/NGMSSelectJob.gd" id="5_0dnxh"]
 [ext_resource type="PackedScene" uid="uid://b2ro8tps610ld" path="res://Scenes/UI/Character Job Button.tscn" id="6_ij4rg"]
+[ext_resource type="Script" path="res://Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd" id="6_lap32"]
 [ext_resource type="Script" path="res://Scripts/UI/New Game Menu/States/NGMSSelectStartingSkills.gd" id="7_qa6fg"]
 [ext_resource type="Script" path="res://Scripts/UI/New Game Menu/States/NGMSEnterName.gd" id="8_bregl"]
 [ext_resource type="Script" path="res://Scripts/UI/New Game Menu/DescriptionDisplayer.gd" id="11_di7lv"]
@@ -35,6 +36,14 @@ description_displayer = NodePath("../../Description Displayer")
 
 [node name="NGMSManageParty" type="Node" parent="NewGameController" node_paths=PackedStringArray("new_character_button", "remove_character_button", "manage_party_buttons_container", "active_party_container", "description_displayer")]
 script = ExtResource("3_j8r74")
+new_character_button = NodePath("../../Manage Party Buttons/Create New Character")
+remove_character_button = NodePath("../../Manage Party Buttons/Remove Character")
+manage_party_buttons_container = NodePath("../../Manage Party Buttons")
+active_party_container = NodePath("../../Active Party Displayer")
+description_displayer = NodePath("../../Description Displayer")
+
+[node name="NGMSRemoveMember" type="Node" parent="NewGameController" node_paths=PackedStringArray("new_character_button", "remove_character_button", "manage_party_buttons_container", "active_party_container", "description_displayer")]
+script = ExtResource("6_lap32")
 new_character_button = NodePath("../../Manage Party Buttons/Create New Character")
 remove_character_button = NodePath("../../Manage Party Buttons/Remove Character")
 manage_party_buttons_container = NodePath("../../Manage Party Buttons")

--- a/Scripts/UI/New Game Menu/States/NGMSManageParty.gd
+++ b/Scripts/UI/New Game Menu/States/NGMSManageParty.gd
@@ -39,7 +39,4 @@ func _on_new_character_button_pressed() -> void:
 	my_state_machine.change_to_state("NGMSSelectJob")
 
 func _on_remove_character_button_pressed() -> void:
-	# TODO: Create a state explicitly for managing the removal of party members.
-	# For now, only the last party member added will be removed.
-	PlayerPartyController.remove_last_member()
-	_check_if_new_characters_can_be_added()
+	my_state_machine.change_to_state("NGMSRemoveMember")

--- a/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
+++ b/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
@@ -17,10 +17,11 @@ func enter(msgs: Dictionary = {}) -> void:
 	remove_character_button.hide()
 	
 	for slot in active_party_container.get_children():
-		if slot is PartyMemberSlot:
-			slot.gui_input.connect(_on_party_member_slot_clicked.bind(slot))
+		if (slot as PartyMemberSlot).combatant != null:
+			slot.enable_highlight_on_hover(true)
+			slot.gui_input.connect(_on_party_member_slot_input.bind(slot))
 
-func _on_party_member_slot_clicked(event, slot: PartyMemberSlot) -> void:
+func _on_party_member_slot_input(event, slot: PartyMemberSlot) -> void:
 	if event is InputEventMouseButton and event.is_pressed():
 		PlayerPartyController.remove_from_party(slot.combatant)
 
@@ -30,7 +31,7 @@ func exit() -> void:
 	new_character_button.pressed.disconnect( _on_new_character_button_pressed )
 	for slot in active_party_container.get_children():
 		if slot is PartyMemberSlot:
-			slot.gui_input.disconnect(_on_party_member_slot_clicked)
+			slot.gui_input.disconnect(_on_party_member_slot_input)
 
 func check_for_handle_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):

--- a/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
+++ b/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
@@ -31,6 +31,7 @@ func exit() -> void:
 	new_character_button.pressed.disconnect( _on_new_character_button_pressed )
 	for slot in active_party_container.get_children():
 		if slot is PartyMemberSlot:
+			slot.enable_highlight_on_hover(false)
 			slot.gui_input.disconnect(_on_party_member_slot_input)
 
 func check_for_handle_input(event: InputEvent) -> void:

--- a/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
+++ b/Scripts/UI/New Game Menu/States/NGMSRemoveMember.gd
@@ -1,0 +1,42 @@
+## State for where we are waiting for user to select which character to remove
+class_name NGMSRemoveMember extends NewGameMenuState
+
+@export var new_character_button:    Button
+@export var remove_character_button: Button
+@export var manage_party_buttons_container: Container
+
+var _old_text_new_character_button : String
+
+func enter(msgs: Dictionary = {}) -> void:
+	_old_text_new_character_button = new_character_button.text
+	new_character_button.text = "Back"
+	
+	active_party_container.show()
+	manage_party_buttons_container.show()
+	new_character_button.pressed.connect( _on_new_character_button_pressed )
+	remove_character_button.hide()
+	
+	for slot in active_party_container.get_children():
+		if slot is PartyMemberSlot:
+			slot.gui_input.connect(_on_party_member_slot_clicked.bind(slot))
+
+func _on_party_member_slot_clicked(event, slot: PartyMemberSlot) -> void:
+	if event is InputEventMouseButton and event.is_pressed():
+		PlayerPartyController.remove_from_party(slot.combatant)
+
+func exit() -> void:
+	new_character_button.text = _old_text_new_character_button
+	remove_character_button.show()
+	new_character_button.pressed.disconnect( _on_new_character_button_pressed )
+	for slot in active_party_container.get_children():
+		if slot is PartyMemberSlot:
+			slot.gui_input.disconnect(_on_party_member_slot_clicked)
+
+func check_for_handle_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		manage_party_buttons_container.hide()
+		my_state_machine.change_to_state("NGMSWaiting")
+		return
+
+func _on_new_character_button_pressed() -> void:
+	my_state_machine.change_to_state("NGMSManageParty")

--- a/Scripts/UI/Party/PartyMemberSlot.gd
+++ b/Scripts/UI/Party/PartyMemberSlot.gd
@@ -29,6 +29,22 @@ func set_combatant(pc: PlayerCombatant) -> void:
 	else:
 		display_contents(false)
 
+func enable_highlight_on_hover(enabled: bool) -> void:
+	if enabled:
+		mouse_entered.connect(highlight)
+		mouse_exited.connect(unhighlight)
+	else:
+		mouse_entered.disconnect(highlight)
+		mouse_exited.disconnect(unhighlight)
+
+func highlight() -> void:
+	if combatant != null:
+		char_name_label.set_text('>' + combatant.char_name)
+
+func unhighlight() -> void:
+	if combatant != null:
+		char_name_label.set_text(combatant.char_name)
+
 ## When the stats of the monitored character changes, update the vital bars.
 func _on_stat_changed(pc: Combatant) -> void:
 	var curr_health: int = combatant.stats.get_curr_hp()


### PR DESCRIPTION
## Changes
* Added `NGMSRemoveMember` which will setup signals for removing the selected character slot
* Clicking `Remove Character` now goes to this state

Note: I saw that mouse clicks are not captured by Godot if we click on say the healthbar of the slot, instead of exactly on the slot background. I'm not sure yet how to fix this as there are no other signals to grab onto.

![Animation](https://github.com/user-attachments/assets/bd367065-24e6-42f0-bd12-f5fad39ce657)
